### PR TITLE
Hyva checkout 1.1.13 compatibility

### DIFF
--- a/Model/Form/AddCustomerTypeRadioButtons.php
+++ b/Model/Form/AddCustomerTypeRadioButtons.php
@@ -62,9 +62,6 @@ class AddCustomerTypeRadioButtons implements EntityFormModifierInterface
 
     public function addInitialSelectField(EntityFormInterface $form): void
     {
-        // The customer type will be shown before the email field.
-        $emailFieldPosition = isset($form->getFields()['email']) ? $form->getFields()['email']->getPosition() : 1;
-
         /** @var Input $select */
         $select = $form->createField(AddCustomerTypeRadioButtons::FIELD_NAME, 'select', [
             'data' => [
@@ -72,7 +69,7 @@ class AddCustomerTypeRadioButtons implements EntityFormModifierInterface
                 'is_auto_save' => false,
                 'label' => __('Customer Type')->render(),
                 'value' => self::TYPE_CONSUMER,
-                'position' => $emailFieldPosition - 1,
+                'position' => 0,
                 'options' => [
                     ['label' => __('Private'), 'value' => self::TYPE_CONSUMER],
                     ['label' => __('Business'), 'value' => self::TYPE_BUSINESS],

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
-    <type name="Hyva\Checkout\Model\Form\AbstractEntityForm">
+    <type name="Hyva\Checkout\Model\Form\EntityForm\EavAttributeBillingAddressForm">
         <arguments>
             <argument name="entityFormModifiers" xsi:type="array">
                 <item name="customer_type" xsi:type="object" sortOrder="940">
@@ -13,6 +13,19 @@
             </argument>
         </arguments>
     </type>
+    <type name="Hyva\Checkout\Model\Form\EntityForm\EavAttributeShippingAddressForm">
+        <arguments>
+            <argument name="entityFormModifiers" xsi:type="array">
+                <item name="customer_type" xsi:type="object" sortOrder="940">
+                    Vendic\HyvaCheckoutHideBusinessFields\Model\Form\AddCustomerTypeRadioButtons
+                </item>
+                <item name="hide_business_fields_for_consumers" xsi:type="object" sortOrder="950">
+                    Vendic\HyvaCheckoutHideBusinessFields\Model\Form\HideBusinessFieldsForConsumers
+                </item>
+            </argument>
+        </arguments>
+    </type>
+
 
     <type name="Vendic\HyvaCheckoutHideBusinessFields\Model\Form\HideBusinessFieldsForConsumers">
         <arguments>

--- a/view/frontend/templates/form/customer_type.phtml
+++ b/view/frontend/templates/form/customer_type.phtml
@@ -19,10 +19,12 @@ use Hyva\Theme\Model\ViewModelRegistry;
 use Magento\Framework\Escaper;
 use Magento\Framework\View\Element\Template;
 use Magewirephp\Magewire\Component\Form as MagewireFormComponent;
+use Vendic\HyvaCheckoutHideBusinessFields\Model\Form\AddCustomerTypeRadioButtons;
 
 $element = $block->getData('element');
 $showLabel = $block->getData('show_label') ?: false;
 $attributes = $element->getAttributes();
+$customerType = $magewire->getAddress() ? $magewire->getAddress()['customer_type'] : AddCustomerTypeRadioButtons::TYPE_CONSUMER;
 ?>
 <div class="block <?= $element->isRequired() ? 'required' : 'not-required' ?>">
     <?php if ($showLabel): ?>
@@ -38,7 +40,7 @@ $attributes = $element->getAttributes();
             <?php foreach ($element->getOptions() as $option): ?>
                 <div>
                     <label class="p-2 bg-white border rounded-lg cursor-pointer text-sm font-bold
-                                  <?= ($magewire->getAddress()['customer_type'] === $option['value']) ? 'border-blue-600 text-blue-600 checked' : 'border-secondary text-secondary' ?>">
+                                  <?= ($customerType === $option['value']) ? 'border-blue-600 text-blue-600 checked' : 'border-secondary text-secondary' ?>">
                         <input type="radio"
                                class="hidden"
                                value="<?= $escaper->escapeHtml($option['value']) ?>"


### PR DESCRIPTION
SInce the email field is now part of the `GuestDetails` we need to make some slight changes.
1. Don't add the selector to all forms, only to shipping and billing
2. Do not reference the email field, set the position to 0.
3. Account for empty ` $magewire->getAddress()`