### PR TITLE
Hyva 1.1.17 compatibility + translations for de_DE, fr_FR, it_IT and es_ES

### DIFF
--- a/Model/Form/AddCustomerTypeRadioButtons.php
+++ b/Model/Form/AddCustomerTypeRadioButtons.php
@@ -55,6 +55,7 @@ class AddCustomerTypeRadioButtons implements EntityFormModifierInterface
     public function saveSelectField(EntityFormInterface $form): void
     {
         $select = $form->getField(self::FIELD_NAME);
+
         if ($select->getValue() !== $select->getPreviousValue()) {
             $this->setCustomerTypeInSession($form, $select->getValue());
         }
@@ -79,6 +80,8 @@ class AddCustomerTypeRadioButtons implements EntityFormModifierInterface
 
         if ($this->getCustomerTypeFromSession($form) !== null) {
             $select->setValue($this->getCustomerTypeFromSession($form));
+            // Set previous value back to null so Magewire can do it's thing and populate it with the actual previous value
+            $select->setData(\Hyva\Checkout\Model\Form\EntityFieldInterface::PREVIOUS_VALUE, null);
         }
 
         $form->addField($select);

--- a/i18n/de_DE.csv
+++ b/i18n/de_DE.csv
@@ -1,0 +1,2 @@
+"Business","Geschäftlich"
+"Private","Privat"

--- a/i18n/es_ES.csv
+++ b/i18n/es_ES.csv
@@ -1,0 +1,2 @@
+"Business","Negocios"
+"Private","Privado"

--- a/i18n/fr_FR.csv
+++ b/i18n/fr_FR.csv
@@ -1,0 +1,2 @@
+"Business","Affaires"
+"Private","Privé"

--- a/i18n/it_IT.csv
+++ b/i18n/it_IT.csv
@@ -1,0 +1,2 @@
+"Business","Affari"
+"Private","Privato"


### PR DESCRIPTION
Fixed broken `getPrevious()` after Hyvä 1.1.17 update, since we restore the value from the session. That breaks the new `getPrevious()` code from Hyvä.