### PR TITLE
HANM-2949: add custom customer type options

### DIFF
--- a/Model/Form/AddCustomerTypeRadioButtons.php
+++ b/Model/Form/AddCustomerTypeRadioButtons.php
@@ -16,8 +16,14 @@ class AddCustomerTypeRadioButtons implements EntityFormModifierInterface
     public const TYPE_CONSUMER = 'consumer';
     public const TYPE_BUSINESS = 'business';
 
+    private array $defaultCustomerTypeOptions = [
+        ['label' => 'Private', 'value' => self::TYPE_CONSUMER],
+        ['label' => 'Business', 'value' => self::TYPE_BUSINESS],
+    ];
+
     public function __construct(
-        private CheckoutSession $checkoutSession
+        private CheckoutSession $checkoutSession,
+        private array $customCustomerTypeOptions = []
     ) {
     }
 
@@ -65,6 +71,8 @@ class AddCustomerTypeRadioButtons implements EntityFormModifierInterface
 
     public function addInitialSelectField(EntityFormInterface $form): void
     {
+        $customerTypeOptions = array_merge($this->defaultCustomerTypeOptions, $this->customCustomerTypeOptions);
+
         /** @var Input $select */
         $select = $form->createField(AddCustomerTypeRadioButtons::FIELD_NAME, 'select', [
             'data' => [
@@ -73,10 +81,7 @@ class AddCustomerTypeRadioButtons implements EntityFormModifierInterface
                 'label' => __('Customer Type')->render(),
                 'value' => self::TYPE_CONSUMER,
                 'position' => 0,
-                'options' => [
-                    ['label' => __('Private'), 'value' => self::TYPE_CONSUMER],
-                    ['label' => __('Business'), 'value' => self::TYPE_BUSINESS],
-                ],
+                'options' => $customerTypeOptions,
             ]
         ]);
 

--- a/Model/Form/HideBusinessFieldsForConsumers.php
+++ b/Model/Form/HideBusinessFieldsForConsumers.php
@@ -44,11 +44,10 @@ class HideBusinessFieldsForConsumers implements EntityFormModifierInterface
         $customerTypeField = $form->getField(AddCustomerTypeRadioButtons::FIELD_NAME);
         if ($customerTypeField->getValue() === AddCustomerTypeRadioButtons::TYPE_CONSUMER) {
             $this->hideFields($form);
+            return;
         }
 
-        if ($customerTypeField->getValue() === AddCustomerTypeRadioButtons::TYPE_BUSINESS) {
-            $this->showFields($form);
-        }
+        $this->showFields($form);
     }
 
     private function hideFields(EntityFormInterface $form): void

--- a/README.md
+++ b/README.md
@@ -19,3 +19,25 @@ This module adds a customer type field to the checkout and hides the business fi
 ```
 composer require vendic/hyva-checkout-hide-business-fields
 ```
+
+### Features
+Allows additional customer type options like Organisation to be added to the existing Consumer and Business options.
+
+To add custom customer type options, you can modify or add the following configuration to your module’s di.xml file:
+```xml
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework/ObjectManager/etc/config.xsd">
+    <type name="Vendic\HyvaCheckoutHideBusinessFields\Model\Form\AddCustomerTypeRadioButtons">
+        <arguments>
+            <!-- Pass custom options to the class -->
+            <argument name="customCustomerTypeOptions" xsi:type="array">
+                <item name="organization" xsi:type="array">
+                    <item name="label" xsi:type="string">Organization</item>
+                    <item name="value" xsi:type="string">organization</item>
+                </item>
+                <!-- Add more custom customer types here if needed -->
+            </argument>
+        </arguments>
+    </type>
+</config>
+```


### PR DESCRIPTION
### Features
Allows additional customer type options like Organisation to be added to the existing Consumer and Business options.

To add custom customer type options, you can modify or add the following configuration to your module’s di.xml file:
```xml
<?xml version="1.0"?>
<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework/ObjectManager/etc/config.xsd">
    <type name="Vendic\HyvaCheckoutHideBusinessFields\Model\Form\AddCustomerTypeRadioButtons">
        <arguments>
            <!-- Pass custom options to the class -->
            <argument name="customCustomerTypeOptions" xsi:type="array">
                <item name="organisation" xsi:type="array">
                    <item name="label" xsi:type="string">Organisation</item>
                    <item name="value" xsi:type="string">organisation</item>
                </item>
                <!-- Add more custom customer types here if needed -->
            </argument>
        </arguments>
    </type>
</config>
```