### PR TITLE
ALFEA-19: fixed wire:model.defer for hyva-checkout v1.3 (csp)

### DIFF
--- a/Model/Form/AddCustomerTypeRadioButtons.php
+++ b/Model/Form/AddCustomerTypeRadioButtons.php
@@ -55,7 +55,6 @@ class AddCustomerTypeRadioButtons implements EntityFormModifierInterface
         /** @var Input $select */
         $select = $form->getField(self::FIELD_NAME);
         $select->setAttribute('wire:model', sprintf('address.%s', self::FIELD_NAME));
-        $select->removeAttribute('wire:model.defer');
     }
 
     public function saveSelectField(EntityFormInterface $form): void

--- a/Model/Form/AddCustomerTypeRadioButtons.php
+++ b/Model/Form/AddCustomerTypeRadioButtons.php
@@ -55,6 +55,8 @@ class AddCustomerTypeRadioButtons implements EntityFormModifierInterface
         /** @var Input $select */
         $select = $form->getField(self::FIELD_NAME);
         $select->setAttribute('wire:model', sprintf('address.%s', self::FIELD_NAME));
+        $select->removeAttribute('wire:model.defer');
+        $select->removeAttribute('wire:auto-save');
     }
 
     public function saveSelectField(EntityFormInterface $form): void

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Hyvä checkout module to hide business fields for consumers",
     "require": {
         "php": "~8.1|~8.2",
-        "hyva-themes/magento2-hyva-checkout": "^1.1.0"
+        "hyva-themes/magento2-hyva-checkout": "^1.3.0"
     },
     "type": "magento2-module",
     "autoload": {


### PR DESCRIPTION

Fixed wire:model.defer for hyva-checkout v1.3 (csp)

In latest hyva-checkout, `wire:auto-save` required `wire:model.defer`